### PR TITLE
Fix miscalculating rewards after adding position

### DIFF
--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Stake.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Stake.cs
@@ -110,13 +110,8 @@ public partial class EcoEarnTokensContract
         stakeInfo.UnlockTime = Context.CurrentBlockTime;
         stakeInfo.LastOperationTime = Context.CurrentBlockTime;
 
-        var rewards = UpdateRewards(poolInfo, stakeInfo);
+        var rewards = ProcessRewards(poolInfo, stakeInfo);
         ProcessStakeInfo(stakeInfo, out var stakedAmount, out var earlyStakedAmount);
-
-        if (rewards > 0)
-        {
-            rewards = ProcessCommissionFee(rewards, poolInfo);
-        }
 
         if (stakedAmount > 0)
         {


### PR DESCRIPTION
Fixed the problem after adding the position, when claiming or unlocking, previous positions' rewards will be miscalculated. 