### PR TITLE
Fix the order of tokenA and tokenB when removing liquidity

### DIFF
--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Liqudity.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Liqudity.cs
@@ -472,8 +472,12 @@ public partial class EcoEarnRewardsContract
 
         var totalSupplyResult = getTotalSupplyOutput!.Results!.First();
 
-        var valueA = new BigIntValue(amount).Mul(reservePairResult.ReserveA).Div(totalSupplyResult.TotalSupply).Value;
-        var valueB = new BigIntValue(amount).Mul(reservePairResult.ReserveB).Div(totalSupplyResult.TotalSupply).Value;
+        var valueA = new BigIntValue(amount)
+            .Mul(reservePairResult.SymbolA == symbolA ? reservePairResult.ReserveA : reservePairResult.ReserveB)
+            .Div(totalSupplyResult.TotalSupply).Value;
+        var valueB = new BigIntValue(amount)
+            .Mul(reservePairResult.SymbolA == symbolA ? reservePairResult.ReserveB : reservePairResult.ReserveA)
+            .Div(totalSupplyResult.TotalSupply).Value;
 
         if (!long.TryParse(valueA, out amountA))
         {

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Liquidity.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Liquidity.cs
@@ -15,7 +15,7 @@ namespace EcoEarn.Contracts.Rewards;
 
 public partial class EcoEarnRewardsContractTests
 {
-    private const string LpSymbol = "ALP SGR-1-ELF";
+    private const string LpSymbol = "ALP ELF-SGR-1";
     
     [Fact]
     public async Task AddLiquidityAndStakeTests()


### PR DESCRIPTION
Fix the problem when removing liquidity, TokenA of liquidity info does not match TokenA from awaken