### PR TITLE
Support multi-project access

### DIFF
--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract.cs
@@ -24,11 +24,13 @@ public partial class EcoEarnPointsContract : EcoEarnPointsContractContainer.EcoE
 
         Assert(input.CommissionRate >= 0, "Invalid commission rate.");
         Assert(input.Recipient == null || !input.Recipient.Value.IsNullOrEmpty(), "Invalid recipient.");
+        Assert(IsAddressValid(input.UpdateAddress), "Invalid update address.");
 
         State.Config.Value = new Config
         {
             CommissionRate = input.CommissionRate,
-            Recipient = input.Recipient ?? Context.Sender
+            Recipient = input.Recipient ?? Context.Sender,
+            DefaultUpdateAddress = input.UpdateAddress
         };
         State.TokenContract.Value = Context.GetContractAddressByName(SmartContractConstants.TokenContractSystemName);
 
@@ -61,6 +63,7 @@ public partial class EcoEarnPointsContract : EcoEarnPointsContractContainer.EcoE
         Assert(input != null, "Invalid input.");
         Assert(input!.CommissionRate >= 0, "Invalid commission rate.");
         Assert(IsAddressValid(input.Recipient), "Invalid recipient.");
+        Assert(IsAddressValid(input.DefaultUpdateAddress), "Invalid update address.");
 
         if (input.Equals(State.Config.Value)) return new Empty();
 

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Helper.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Helper.cs
@@ -43,4 +43,10 @@ public partial class EcoEarnPointsContract
     {
         return Context.CurrentBlockTime < endTime;
     }
+    
+    private Address GetUpdateAddress(Hash dappId)
+    {
+        var dappInfo = State.DappInfoMap[dappId];
+        return dappInfo.Config?.UpdateAddress == null ? State.Config.Value.DefaultUpdateAddress : dappInfo.Config.UpdateAddress;
+    }
 }

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Helper.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Helper.cs
@@ -31,10 +31,12 @@ public partial class EcoEarnPointsContract
         return input != null && !input.Value.IsNullOrEmpty();
     }
 
-    private void CheckDAppAdminPermission(Hash id)
+    private DappInfo GetAndCheckDAppAdminPermission(Hash id)
     {
         var dappInfo = State.DappInfoMap[id];
         Assert(dappInfo != null && dappInfo.Admin == Context.Sender, "No permission.");
+
+        return dappInfo;
     }
 
     private bool CheckPoolEnabled(Timestamp endTime)

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Pool.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Pool.cs
@@ -81,7 +81,7 @@ public partial class EcoEarnPointsContract
     {
         Assert(input != null, "Invalid input.");
         Assert(IsHashValid(input!.DappId), "Invalid dapp id.");
-        var dappInfo = GetAndCheckDAppAdminPermission(input.DappId);
+        GetAndCheckDAppAdminPermission(input.DappId);
         ValidatePointsPoolConfig(input);
         CheckPointExists(input.DappId, input.PointsName);
 
@@ -105,7 +105,7 @@ public partial class EcoEarnPointsContract
             {
                 Seconds = input.EndTime
             },
-            UpdateAddress = dappInfo.Config.UpdateAddress
+            UpdateAddress = GetUpdateAddress(input.DappId)
         };
 
         State.PoolInfoMap[poolId] = new PoolInfo
@@ -120,7 +120,10 @@ public partial class EcoEarnPointsContract
 
         State.PoolDataMap[poolId] = new PoolData
         {
-            LastRewardsUpdateTime = Context.CurrentBlockTime,
+            LastRewardsUpdateTime = new Timestamp
+            {
+                Seconds = input.StartTime
+            },
             PoolId = poolId
         };
 
@@ -172,7 +175,7 @@ public partial class EcoEarnPointsContract
 
         var poolInfo = GetPool(input!.PoolId);
         Assert(!CheckPoolEnabled(poolInfo.Config.EndTime), "Can not restart yet.");
-        var dappInfo = GetAndCheckDAppAdminPermission(poolInfo.DappId);
+        GetAndCheckDAppAdminPermission(poolInfo.DappId);
 
         poolInfo.Config = new PointsPoolConfig
         {
@@ -188,14 +191,17 @@ public partial class EcoEarnPointsContract
             {
                 Seconds = input.EndTime
             },
-            UpdateAddress = dappInfo.Config.UpdateAddress
+            UpdateAddress = GetUpdateAddress(poolInfo.DappId)
         };
 
         var totalReward = CalculateTotalRewardAmount(input.StartTime, input.EndTime, input.RewardPerSecond);
 
         State.PoolDataMap[poolInfo.PoolId] = new PoolData
         {
-            LastRewardsUpdateTime = Context.CurrentBlockTime,
+            LastRewardsUpdateTime = new Timestamp
+            {
+                Seconds = input.StartTime
+            },
             PoolId = poolInfo.PoolId
         };
 

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Pool.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Pool.cs
@@ -172,7 +172,7 @@ public partial class EcoEarnPointsContract
 
         var poolInfo = GetPool(input!.PoolId);
         Assert(!CheckPoolEnabled(poolInfo.Config.EndTime), "Can not restart yet.");
-        GetAndCheckDAppAdminPermission(poolInfo.DappId);
+        var dappInfo = GetAndCheckDAppAdminPermission(poolInfo.DappId);
 
         poolInfo.Config = new PointsPoolConfig
         {
@@ -187,7 +187,8 @@ public partial class EcoEarnPointsContract
             EndTime = new Timestamp
             {
                 Seconds = input.EndTime
-            }
+            },
+            UpdateAddress = dappInfo.Config.UpdateAddress
         };
 
         var totalReward = CalculateTotalRewardAmount(input.StartTime, input.EndTime, input.RewardPerSecond);

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_View.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_View.cs
@@ -25,6 +25,9 @@ public partial class EcoEarnPointsContract
         if (!IsHashValid(input) || State.PoolInfoMap[input]?.PoolId == null) return new GetPoolInfoOutput();
 
         var info = State.PoolInfoMap[input];
+
+        var dappInfo = State.DappInfoMap[info.DappId];
+        info.Config.UpdateAddress = dappInfo.Config.UpdateAddress;
         var output = new GetPoolInfoOutput
         {
             PoolInfo = info,

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_View.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_View.cs
@@ -26,8 +26,7 @@ public partial class EcoEarnPointsContract
 
         var info = State.PoolInfoMap[input];
 
-        var dappInfo = State.DappInfoMap[info.DappId];
-        info.Config.UpdateAddress = dappInfo.Config.UpdateAddress;
+        info.Config.UpdateAddress = GetUpdateAddress(info.DappId);
         var output = new GetPoolInfoOutput
         {
             PoolInfo = info,

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract.cs
@@ -19,6 +19,13 @@ public partial class EcoEarnRewardsContract : EcoEarnRewardsContractContainer.Ec
         State.Admin.Value = input.Admin ?? Context.Sender;
         State.EcoEarnPointsContract.Value = input.EcoearnPointsContract;
         State.EcoEarnTokensContract.Value = input.EcoearnTokensContract;
+        
+        Assert(IsAddressValid(input.UpdateAddress), "Invalid update address.");
+
+        State.Config.Value = new Config
+        {
+            DefaultUpdateAddress = input.UpdateAddress
+        };
 
         State.TokenContract.Value = Context.GetContractAddressByName(SmartContractConstants.TokenContractSystemName);
 
@@ -39,6 +46,25 @@ public partial class EcoEarnRewardsContract : EcoEarnRewardsContractContainer.Ec
         Context.Fire(new AdminSet
         {
             Admin = input
+        });
+
+        return new Empty();
+    }
+
+    public override Empty SetConfig(Config input)
+    {
+        CheckAdminPermission();
+
+        Assert(input != null, "Invalid input.");
+        Assert(IsAddressValid(input.DefaultUpdateAddress), "Invalid update address.");
+
+        if (input.Equals(State.Config.Value)) return new Empty();
+
+        State.Config.Value = input;
+
+        Context.Fire(new ConfigSet
+        {
+            Config = input
         });
 
         return new Empty();

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContractState.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContractState.cs
@@ -7,6 +7,7 @@ public partial class EcoEarnRewardsContractState : ContractState
 {
     public SingletonState<bool> Initialized { get; set; }
     public SingletonState<Address> Admin { get; set; }
+    public SingletonState<Config> Config { get; set; }
 
     // <DappId, DappInfo>
     public MappedState<Hash, DappInfo> DappInfoMap { get; set; }

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Helper.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Helper.cs
@@ -30,9 +30,11 @@ public partial class EcoEarnRewardsContract
         return input != null && !input.Value.IsNullOrEmpty();
     }
 
-    private void CheckDAppAdminPermission(Hash id)
+    private DappInfo GetAndCheckDAppAdminPermission(Hash id)
     {
         var dappInfo = State.DappInfoMap[id];
         Assert(dappInfo != null && dappInfo.Admin == Context.Sender, "No permission.");
+
+        return dappInfo;
     }
 }

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Helper.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Helper.cs
@@ -37,4 +37,9 @@ public partial class EcoEarnRewardsContract
 
         return dappInfo;
     }
+    
+    private Address GetUpdateAddress(DappInfo dappInfo)
+    {
+        return dappInfo.Config?.UpdateAddress == null ? State.Config.Value.DefaultUpdateAddress : dappInfo.Config.UpdateAddress;
+    }
 }

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Liqudity.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Liqudity.cs
@@ -36,7 +36,7 @@ public partial class EcoEarnRewardsContract
 
         Assert(
             RecoverAddressFromSignature(ComputeAddLiquidityAndStakeHash(input), input.Signature) ==
-            dappInfo!.Config.UpdateAddress, "Signature not valid.");
+            GetUpdateAddress(dappInfo), "Signature not valid.");
 
         var claimInfo = GetClaimInfoFromClaimId(stakeInput.ClaimIds.FirstOrDefault());
         CheckMaximumAmount(State.TokenContract.Value, stakeInput.DappId, claimInfo.ClaimedSymbol, stakeInput.Amount);
@@ -145,7 +145,7 @@ public partial class EcoEarnRewardsContract
         Assert(dappInfo != null, "Dapp id not exists.");
         Assert(
             RecoverAddressFromSignature(ComputeRemoveLiquidityHash(input), input.Signature) ==
-            dappInfo!.Config.UpdateAddress, "Signature not valid.");
+            GetUpdateAddress(dappInfo), "Signature not valid.");
 
         PrepareRemoveLiquidity(liquidityInfo.LpSymbol, liquidityInput.LpAmount,
             CalculateUserAddressHash(liquidityInput.DappId, Context.Sender),
@@ -210,7 +210,7 @@ public partial class EcoEarnRewardsContract
         Assert(dappInfo != null, "Dapp id not exists.");
         Assert(
             RecoverAddressFromSignature(ComputeStakeLiquidityHash(input), input.Signature) ==
-            dappInfo!.Config.UpdateAddress, "Signature not valid.");
+            GetUpdateAddress(dappInfo), "Signature not valid.");
 
         var stakeId = GetStakeId(input.PoolId);
 

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Reward.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Reward.cs
@@ -59,7 +59,7 @@ public partial class EcoEarnRewardsContract
         ValidateSignature(input.Signature, input.ExpirationTime);
         Assert(
             RecoverAddressFromSignature(ComputeWithdrawInputHash(input), input.Signature) ==
-            dappInfo!.Config.UpdateAddress, "Signature not valid.");
+            GetUpdateAddress(dappInfo), "Signature not valid.");
 
         var claimInfo = GetClaimInfoFromClaimId(input.ClaimIds.FirstOrDefault());
         CheckMaximumAmount(State.TokenContract.Value, input.DappId, claimInfo.ClaimedSymbol, input.Amount);
@@ -102,7 +102,7 @@ public partial class EcoEarnRewardsContract
         ValidateSignature(input.Signature, stakeInput.ExpirationTime);
         Assert(
             RecoverAddressFromSignature(ComputeEarlyStakeInputHash(input), input.Signature) ==
-            dappInfo!.Config.UpdateAddress, "Signature not valid.");
+            GetUpdateAddress(dappInfo), "Signature not valid.");
 
         var claimInfo = GetClaimInfoFromClaimId(stakeInput.ClaimIds.FirstOrDefault());
         CheckMaximumAmount(State.TokenContract.Value, stakeInput.DappId, claimInfo.ClaimedSymbol,

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_View.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_View.cs
@@ -10,6 +10,11 @@ public partial class EcoEarnRewardsContract
         return State.Admin.Value;
     }
 
+    public override Config GetConfig(Empty input)
+    {
+        return State.Config.Value;
+    }
+
     public override DappInfo GetDappInfo(Hash input)
     {
         return IsHashValid(input) ? State.DappInfoMap[input] : new DappInfo();

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Helper.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Helper.cs
@@ -31,10 +31,12 @@ public partial class EcoEarnTokensContract
         return input != null && !input.Value.IsNullOrEmpty();
     }
 
-    private void CheckDAppAdminPermission(Hash id)
+    private DappInfo GetAndCheckDAppAdminPermission(Hash id)
     {
         var info = State.DappInfoMap[id];
         Assert(info != null && info.Admin == Context.Sender, "No permission.");
+
+        return info;
     }
 
     private bool CheckPoolEnabled(Timestamp endBlockNumber)

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Reward.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Reward.cs
@@ -64,7 +64,7 @@ public partial class EcoEarnTokensContract
         Assert(input.Recipient == null || !input.Recipient.Value.IsNullOrEmpty(), "Invalid recipient.");
 
         var poolInfo = GetPool(input.PoolId);
-        CheckDAppAdminPermission(poolInfo.DappId);
+        GetAndCheckDAppAdminPermission(poolInfo.DappId);
 
         Assert(!CheckPoolEnabled(poolInfo.Config.EndTime), "Pool not closed.");
 

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_View.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_View.cs
@@ -7,6 +7,8 @@ namespace EcoEarn.Contracts.Tokens;
 
 public partial class EcoEarnTokensContract
 {
+    #region public
+
     public override Address GetAdmin(Empty input)
     {
         return State.Admin.Value;
@@ -104,6 +106,30 @@ public partial class EcoEarnTokensContract
         };
     }
 
+    public override BoolValue IsInUnlockWindow(IsInUnlockWindowInput input)
+    {
+        var poolInfo = State.PoolInfoMap[input.PoolId];
+        if (poolInfo?.PoolId == null) return new BoolValue();
+        
+        var stakeId = State.UserStakeIdMap[input.PoolId][input.Account];
+        if (stakeId == null) return new BoolValue();
+
+        var stakeInfo = State.StakeInfoMap[stakeId];
+        
+        var remainTime = CalculateRemainTime(stakeInfo, poolInfo.Config.UnlockWindowDuration);
+        if (stakeInfo != null && stakeInfo.UnlockTime == null && IsInUnlockWindow(stakeInfo, remainTime))
+            return new BoolValue
+            {
+                Value = true
+            };
+
+        return new BoolValue();
+    }
+
+    #endregion
+
+    #region private
+
     private RewardInfo ProcessGetReward(Hash stakeId)
     {
         var rewardInfo = new RewardInfo();
@@ -145,4 +171,6 @@ public partial class EcoEarnTokensContract
 
         return rewardInfo;
     }
+
+    #endregion
 }

--- a/protobuf/ecoearn_points.proto
+++ b/protobuf/ecoearn_points.proto
@@ -24,10 +24,10 @@ service EcoEarnPointsContract {
   rpc Register (RegisterInput) returns (google.protobuf.Empty) {}
   rpc SetDappAdmin (SetDappAdminInput) returns (google.protobuf.Empty) {}
   rpc GetDappInfo (aelf.Hash) returns (DappInfo) {option (aelf.is_view) = true;}
+  rpc SetDappConfig (SetDappConfigInput) returns (google.protobuf.Empty) {}
   rpc CreatePointsPool (CreatePointsPoolInput) returns (google.protobuf.Empty) {}
   rpc SetPointsPoolEndTime (SetPointsPoolEndTimeInput) returns (google.protobuf.Empty) {}
   rpc RestartPointsPool (RestartPointsPoolInput) returns (google.protobuf.Empty) {}
-  rpc SetPointsPoolUpdateAddress (SetPointsPoolUpdateAddressInput) returns (google.protobuf.Empty) {}
   rpc SetPointsPoolRewardConfig (SetPointsPoolRewardConfigInput) returns (google.protobuf.Empty) {}
   rpc SetPointsPoolRewardPerSecond (SetPointsPoolRewardPerSecondInput) returns (google.protobuf.Empty) {}
   rpc GetPoolInfo (aelf.Hash) returns (GetPoolInfoOutput) {option (aelf.is_view) = true;}
@@ -48,21 +48,34 @@ message InitializeInput {
   aelf.Address ecoearn_rewards_contract = 4;
   int64 commission_rate = 5;
   aelf.Address recipient = 6;
+  aelf.Address update_address = 7;
 }
 
 message Config {
   int64 commission_rate = 1;
   aelf.Address recipient = 2;
+  aelf.Address default_update_address = 3;
 }
 
 message RegisterInput {
   aelf.Hash dapp_id = 1;
   aelf.Address admin = 2;
+  aelf.Address update_address = 3;
 }
 
 message DappInfo {
   aelf.Hash dapp_id = 1;
   aelf.Address admin = 2;
+  DappConfig config = 3;
+}
+
+message DappConfig {
+  aelf.Address update_address = 1;
+}
+
+message SetDappConfigInput {
+  aelf.Hash dapp_id = 1;
+  DappConfig config = 2;
 }
 
 message CreatePointsPoolInput {
@@ -72,9 +85,8 @@ message CreatePointsPoolInput {
   int64 start_time = 4;
   int64 end_time = 5;
   int64 reward_per_second = 6;
-  aelf.Address update_address = 7;
-  repeated int64 release_periods = 8;
-  int64 claim_interval = 9;
+  repeated int64 release_periods = 7;
+  int64 claim_interval = 8;
 }
 
 message PointsPoolConfig {
@@ -151,11 +163,6 @@ message RestartPointsPoolInput {
   int64 claim_interval = 8;
 }
 
-message SetPointsPoolUpdateAddressInput {
-  aelf.Hash pool_id = 1;
-  aelf.Address update_address = 2;
-}
-
 message SetPointsPoolRewardConfigInput {
   aelf.Hash pool_id = 1;
   repeated int64 release_periods = 2;
@@ -198,6 +205,13 @@ message Registered {
   option (aelf.is_event) = true;
   aelf.Hash dapp_id = 1;
   aelf.Address admin = 2;
+  DappConfig config = 3;
+}
+
+message DappConfigSet {
+  option (aelf.is_event) = true;
+  aelf.Hash dapp_id = 1;
+  DappConfig config = 2;
 }
 
 message PointsPoolCreated {
@@ -245,12 +259,6 @@ message PointsPoolRestarted {
   aelf.Hash pool_id = 1;
   PointsPoolConfig config = 2;
   int64 amount = 3;
-}
-
-message PointsPoolUpdateAddressSet {
-  option (aelf.is_event) = true;
-  aelf.Hash pool_id = 1;
-  aelf.Address update_address = 2;
 }
 
 message PointsPoolRewardConfigSet {

--- a/protobuf/ecoearn_rewards.proto
+++ b/protobuf/ecoearn_rewards.proto
@@ -17,6 +17,8 @@ service EcoEarnRewardsContract {
   rpc Initialize (InitializeInput) returns (google.protobuf.Empty) {}
   rpc SetAdmin (aelf.Address) returns (google.protobuf.Empty) {}
   rpc GetAdmin (google.protobuf.Empty) returns (aelf.Address) {option (aelf.is_view) = true;}
+  rpc SetConfig (Config) returns (google.protobuf.Empty) {}
+  rpc GetConfig (google.protobuf.Empty) returns (Config) {option (aelf.is_view) = true;}
 
   // dapp
   rpc Register (RegisterInput) returns (google.protobuf.Empty) {}
@@ -41,6 +43,11 @@ message InitializeInput {
   aelf.Address admin = 1;
   aelf.Address ecoearn_points_contract = 2;
   aelf.Address ecoearn_tokens_contract = 3;
+  aelf.Address update_address = 4;
+}
+
+message Config {
+  aelf.Address default_update_address = 1;
 }
 
 message RegisterInput {
@@ -185,6 +192,11 @@ message LiquidityInfos {
 }
 
 // log event
+message ConfigSet {
+  option (aelf.is_event) = true;
+  Config config = 1;
+}
+
 message AdminSet {
   option (aelf.is_event) = true;
   aelf.Address admin = 1;

--- a/protobuf/ecoearn_tokens.proto
+++ b/protobuf/ecoearn_tokens.proto
@@ -46,16 +46,26 @@ service EcoEarnTokensContract {
   rpc GetConfig (google.protobuf.Empty) returns (Config) {option (aelf.is_view) = true;}
   rpc SetAdmin (aelf.Address) returns (google.protobuf.Empty) {}
   rpc GetAdmin (google.protobuf.Empty) returns (aelf.Address) {option (aelf.is_view) = true;}
+  
+  rpc StakeOnBehalf (StakeOnBehalfInput) returns (google.protobuf.Empty) {}
+  rpc IsInUnlockWindow (IsInUnlockWindowInput) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
+  rpc SetDappConfig (SetDappConfigInput) returns (google.protobuf.Empty) {}
 }
 
 message RegisterInput {
   aelf.Hash dapp_id = 1;
   aelf.Address admin = 2;
+  aelf.Address payment_address = 3;
 }
 
 message DappInfo {
   aelf.Hash dapp_id = 1;
   aelf.Address admin = 2;
+  DappConfig config = 3;
+}
+
+message DappConfig {
+  aelf.Address payment_address = 1;
 }
 
 message CreateTokensPoolInput {
@@ -67,10 +77,10 @@ message CreateTokensPoolInput {
   string staking_token = 6;
   int64 fixed_boost_factor = 7;
   int64 minimum_amount = 8;
-  int64 maximum_stake_duration = 9;
-  int64 minimum_claim_amount = 10;
-  int64 minimum_add_liquidity_amount = 11;
-  int64 minimum_stake_duration = 12;
+  int64 minimum_stake_duration = 9;
+  int64 maximum_stake_duration = 10;
+  int64 minimum_claim_amount = 11;
+  int64 minimum_add_liquidity_amount = 12;
   aelf.Address reward_token_contract = 13;
   aelf.Address stake_token_contract = 14;
   aelf.Address swap_contract = 15;
@@ -268,11 +278,29 @@ message PoolAddressInfo {
   aelf.Address reward_address = 2;
 }
 
+message StakeOnBehalfInput {
+  aelf.Hash pool_id = 1;
+  int64 amount = 2;
+  int64 period = 3;
+  aelf.Address account = 4;
+}
+
+message IsInUnlockWindowInput {
+  aelf.Hash pool_id = 1;
+  aelf.Address account = 2;
+}
+
+message SetDappConfigInput {
+  aelf.Hash dapp_id = 1;
+  DappConfig config = 2;
+}
+
 // log event
 message Registered {
   option (aelf.is_event) = true;
   aelf.Hash dapp_id = 1;
   aelf.Address admin = 2;
+  DappConfig config = 3;
 }
 
 message TokensPoolCreated {
@@ -381,4 +409,17 @@ message Renewed {
   option (aelf.is_event) = true;
   StakeInfo stake_info = 1;
   PoolData pool_data = 2;
+}
+
+message StakedOnBehalf {
+  option (aelf.is_event) = true;
+  StakeInfo stake_info = 1;
+  PoolData pool_data = 2;
+  aelf.Address payer = 3;
+}
+
+message DappConfigSet {
+  option (aelf.is_event) = true;
+  aelf.Hash dapp_id = 1;
+  DappConfig config = 2;
 }

--- a/test/EcoEarn.Contracts.Points.Tests/EcoEarnPointsContractTests_Admin.cs
+++ b/test/EcoEarn.Contracts.Points.Tests/EcoEarnPointsContractTests_Admin.cs
@@ -19,7 +19,8 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
             Recipient = User2Address,
             Admin = UserAddress,
             EcoearnTokensContract = EcoEarnTokensContractAddress,
-            EcoearnRewardsContract = EcoEarnRewardsContractAddress
+            EcoearnRewardsContract = EcoEarnRewardsContractAddress,
+            UpdateAddress = DefaultAddress
         };
 
         var result = await EcoEarnPointsContractStub.Initialize.SendAsync(input);
@@ -45,7 +46,8 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
             PointsContract = PointsContractAddress,
             CommissionRate = 100,
             EcoearnTokensContract = DefaultAddress,
-            EcoearnRewardsContract = DefaultAddress
+            EcoearnRewardsContract = DefaultAddress,
+            UpdateAddress = DefaultAddress
         };
 
         var result = await EcoEarnPointsContractStub.Initialize.SendAsync(input);
@@ -123,6 +125,27 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
             Recipient = new Address()
         });
         result.TransactionResult.Error.ShouldContain("Invalid recipient.");
+        
+        result = await EcoEarnPointsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            PointsContract = DefaultAddress,
+            EcoearnTokensContract = DefaultAddress,
+            EcoearnRewardsContract = DefaultAddress,
+            CommissionRate = 0,
+            Recipient = DefaultAddress
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid update address.");
+        
+        result = await EcoEarnPointsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            PointsContract = DefaultAddress,
+            EcoearnTokensContract = DefaultAddress,
+            EcoearnRewardsContract = DefaultAddress,
+            CommissionRate = 0,
+            Recipient = DefaultAddress,
+            UpdateAddress = new Address()
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid update address.");
 
         // sender != author
         result = await EcoEarnPointsContractUserStub.Initialize.SendWithExceptionAsync(new InitializeInput
@@ -171,11 +194,13 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
         var config = await EcoEarnPointsContractStub.GetConfig.CallAsync(new Empty());
         config.CommissionRate.ShouldBe(1000);
         config.Recipient.ShouldBe(User2Address);
+        
 
         var input = new Config
         {
             CommissionRate = 50,
-            Recipient = DefaultAddress
+            Recipient = DefaultAddress,
+            DefaultUpdateAddress = DefaultAddress
         };
         var result = await EcoEarnPointsContractStub.SetConfig.SendAsync(input);
         result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
@@ -227,6 +252,23 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
             });
             result.TransactionResult.Error.ShouldContain("Invalid recipient.");
         }
+        {
+            var result = await EcoEarnPointsContractStub.SetConfig.SendWithExceptionAsync(new Config
+            {
+                CommissionRate = 50,
+                Recipient = DefaultAddress
+            });
+            result.TransactionResult.Error.ShouldContain("Invalid update address.");
+        }
+        {
+            var result = await EcoEarnPointsContractStub.SetConfig.SendWithExceptionAsync(new Config
+            {
+                CommissionRate = 50,
+                Recipient = DefaultAddress,
+                DefaultUpdateAddress = new Address()
+            });
+            result.TransactionResult.Error.ShouldContain("Invalid update address.");
+        }
     }
 
     private async Task Initialize()
@@ -237,12 +279,14 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
             CommissionRate = 1000,
             Recipient = User2Address,
             EcoearnTokensContract = EcoEarnTokensContractAddress,
-            EcoearnRewardsContract = EcoEarnRewardsContractAddress
+            EcoearnRewardsContract = EcoEarnRewardsContractAddress,
+            UpdateAddress = DefaultAddress
         });
         await EcoEarnRewardsContractStub.Initialize.SendAsync(new Rewards.InitializeInput
         {
             EcoearnTokensContract = EcoEarnTokensContractAddress,
-            EcoearnPointsContract = EcoEarnPointsContractAddress
+            EcoearnPointsContract = EcoEarnPointsContractAddress,
+            UpdateAddress = DefaultAddress
         });
         await PointsContractStub.Initialize.SendAsync(new TestPointsContract.InitializeInput
         {

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Admin.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Admin.cs
@@ -16,7 +16,8 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
         {
             Admin = UserAddress,
             EcoearnPointsContract = EcoEarnPointsContractAddress,
-            EcoearnTokensContract = EcoEarnTokensContractAddress
+            EcoearnTokensContract = EcoEarnTokensContractAddress,
+            UpdateAddress = DefaultAddress
         };
 
         var result = await EcoEarnRewardsContractStub.Initialize.SendAsync(input);
@@ -49,6 +50,34 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
             EcoearnPointsContract = new Address()
         });
         result.TransactionResult.Error.ShouldContain("Invalid ecoearn points contract.");
+        
+        result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            EcoearnPointsContract = DefaultAddress
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid ecoearn tokens contract.");
+        
+        result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            EcoearnPointsContract = DefaultAddress,
+            EcoearnTokensContract = new Address()
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid ecoearn tokens contract.");
+        
+        result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            EcoearnPointsContract = DefaultAddress,
+            EcoearnTokensContract = DefaultAddress
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid update address.");
+        
+        result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            EcoearnPointsContract = DefaultAddress,
+            EcoearnTokensContract = DefaultAddress,
+            UpdateAddress = new Address()
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid update address.");
 
         // sender != author
         result = await UserEcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
@@ -96,7 +125,8 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
         await EcoEarnRewardsContractStub.Initialize.SendAsync(new InitializeInput
         {
             EcoearnPointsContract = EcoEarnPointsContractAddress,
-            EcoearnTokensContract = EcoEarnTokensContractAddress
+            EcoearnTokensContract = EcoEarnTokensContractAddress,
+            UpdateAddress = DefaultAddress
         });
         await EcoEarnPointsContractStub.Initialize.SendAsync(new Points.InitializeInput
         {
@@ -104,7 +134,8 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
             CommissionRate = 1000,
             Recipient = User2Address,
             EcoearnTokensContract = EcoEarnTokensContractAddress,
-            EcoearnRewardsContract = EcoEarnRewardsContractAddress
+            EcoearnRewardsContract = EcoEarnRewardsContractAddress,
+            UpdateAddress = DefaultAddress
         });
         await EcoEarnTokensContractStub.Initialize.SendAsync(new Tokens.InitializeInput
         {

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_DApp.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_DApp.cs
@@ -67,12 +67,6 @@ public partial class EcoEarnRewardsContractTests
 
         result = await EcoEarnRewardsContractStub.Register.SendWithExceptionAsync(new RegisterInput
         {
-            DappId = HashHelper.ComputeFrom("test")
-        });
-        result.TransactionResult.Error.ShouldContain("Invalid update address.");
-
-        result = await EcoEarnRewardsContractStub.Register.SendWithExceptionAsync(new RegisterInput
-        {
             DappId = HashHelper.ComputeFrom("test"),
             UpdateAddress = new Address()
         });

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Reward.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Reward.cs
@@ -70,7 +70,8 @@ public partial class EcoEarnRewardsContractTests
         await EcoEarnRewardsContractStub.Initialize.SendAsync(new InitializeInput
         {
             EcoearnPointsContract = DefaultAddress,
-            EcoearnTokensContract = DefaultAddress
+            EcoearnTokensContract = DefaultAddress,
+            UpdateAddress = DefaultAddress
         });
 
         result = await EcoEarnRewardsContractStub.Claim.SendWithExceptionAsync(new ClaimInput());
@@ -772,8 +773,7 @@ public partial class EcoEarnRewardsContractTests
         await Initialize();
         await EcoEarnRewardsContractStub.Register.SendAsync(new RegisterInput
         {
-            DappId = _appId,
-            UpdateAddress = DefaultAddress
+            DappId = _appId
         });
         await CreateToken();
 


### PR DESCRIPTION
1. Add default update address when initializing and can be set later
2. Move the update address from the pool configuration to the DApp configuration
3. Remove `SetPointsPoolUpdateAddress` and update address can be set by `SetDappConfig`
4. Add `StakeOnBehalf` so other projects can stake for their user
5. Add `IsInUnlockWindow` so the unlock window can be avoided before staking
close #10 