### PR TITLE
Release v1.8.0

### DIFF
--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContractReferenceState.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContractReferenceState.cs
@@ -2,7 +2,7 @@ using AElf.Contracts.MultiToken;
 using AElf.Standards.ACS0;
 using EcoEarn.Contracts.Rewards;
 using EcoEarn.Contracts.Tokens;
-using Points.Contracts.PointsContract;
+using Points.Contracts.Point;
 
 namespace EcoEarn.Contracts.Points;
 

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Pool.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Pool.cs
@@ -5,7 +5,7 @@ using AElf.CSharp.Core;
 using AElf.Sdk.CSharp;
 using AElf.Types;
 using Google.Protobuf.WellKnownTypes;
-using Points.Contracts.PointsContract;
+using Points.Contracts.Point;
 
 namespace EcoEarn.Contracts.Points;
 
@@ -43,6 +43,8 @@ public partial class EcoEarnPointsContract
         };
 
         State.DappInfoMap[input.DappId] = dappInfo;
+        
+        Join(Context.Sender);
 
         Context.Fire(new Registered
         {
@@ -369,6 +371,11 @@ public partial class EcoEarnPointsContract
         Assert(poolInfo != null, "Pool not exists.");
 
         return poolInfo;
+    }
+
+    private void Join(Address registrant)
+    {
+        State.EcoEarnRewardsContract.JoinFor.Send(registrant);
     }
 
     #endregion

--- a/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Reward.cs
+++ b/contract/EcoEarn.Contracts.Points/EcoEarnPointsContract_Reward.cs
@@ -59,6 +59,8 @@ public partial class EcoEarnPointsContract
         ChargeCommissionFee(poolInfo, input.Amount, out var claimedAmount);
 
         CallRewardsContractClaim(poolInfo, claimedAmount, input.Seed);
+        
+        Join(Context.Sender);
 
         Context.Fire(new Claimed
         {

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarn.Contracts.Rewards.csproj
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarn.Contracts.Rewards.csproj
@@ -20,6 +20,9 @@
         <ContractReference Include="..\..\protobuf\token_contract.proto">
             <Link>Protobuf\Proto\token_contract.proto</Link>
         </ContractReference>
+        <ContractReference Include="..\..\protobuf\points_contract.proto">
+            <Link>Protobuf\Proto\points_contract.proto</Link>
+        </ContractReference>
         <ContractReference Include="..\..\protobuf\ecoearn_points.proto">
             <Link>Protobuf\Proto\ecoearn_points.proto</Link>
         </ContractReference>

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract.cs
@@ -15,10 +15,12 @@ public partial class EcoEarnRewardsContract : EcoEarnRewardsContractContainer.Ec
         Assert(input.Admin == null || !input.Admin.Value.IsNullOrEmpty(), "Invalid admin.");
         Assert(IsAddressValid(input.EcoearnPointsContract), "Invalid ecoearn points contract.");
         Assert(IsAddressValid(input.EcoearnTokensContract), "Invalid ecoearn tokens contract.");
-
+        Assert(IsAddressValid(input.PointsContract), "Invalid points contract.");
+        
         State.Admin.Value = input.Admin ?? Context.Sender;
         State.EcoEarnPointsContract.Value = input.EcoearnPointsContract;
         State.EcoEarnTokensContract.Value = input.EcoearnTokensContract;
+        State.PointsContract.Value = input.PointsContract;
         
         Assert(IsAddressValid(input.UpdateAddress), "Invalid update address.");
 

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContractReferenceState.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContractReferenceState.cs
@@ -2,6 +2,7 @@ using AElf.Contracts.MultiToken;
 using AElf.Standards.ACS0;
 using EcoEarn.Contracts.Points;
 using EcoEarn.Contracts.Tokens;
+using Points.Contracts.Point;
 
 namespace EcoEarn.Contracts.Rewards;
 
@@ -9,6 +10,7 @@ public partial class EcoEarnRewardsContractState
 {
     internal ACS0Container.ACS0ReferenceState GenesisContract { get; set; }
     internal TokenContractContainer.TokenContractReferenceState TokenContract { get; set; }
+    internal PointsContractContainer.PointsContractReferenceState PointsContract { get; set; }
     internal EcoEarnPointsContractContainer.EcoEarnPointsContractReferenceState EcoEarnPointsContract { get; set; }
     internal EcoEarnTokensContractContainer.EcoEarnTokensContractReferenceState EcoEarnTokensContract { get; set; }
 }

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContractState.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContractState.cs
@@ -14,6 +14,11 @@ public partial class EcoEarnRewardsContractState : ContractState
 
     // <ClaimId, ClaimInfo>
     public MappedState<Hash, ClaimInfo> ClaimInfoMap { get; set; }
+    // SignatureHash
     public MappedState<Hash, bool> SignatureMap { get; set; }
+    // <LiquidityId, LiquidityInfo>
     public MappedState<Hash, LiquidityInfo> LiquidityInfoMap { get; set; }
+    
+    public MappedState<Address, bool> JoinRecord { get; set; }
+    public SingletonState<PointsContractConfig> PointsContractConfig { get; set; }
 }

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_DApp.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_DApp.cs
@@ -37,6 +37,8 @@ public partial class EcoEarnRewardsContract
 
         State.DappInfoMap[input.DappId] = info;
 
+        Join(Context.Sender);
+
         Context.Fire(new Registered
         {
             DappId = info.DappId,

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Points.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_Points.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using AElf.Sdk.CSharp;
+using AElf.Types;
+using Google.Protobuf.WellKnownTypes;
+using Points.Contracts.Point;
+
+namespace EcoEarn.Contracts.Rewards;
+
+public partial class EcoEarnRewardsContract
+{
+    #region public
+
+    public override Empty SetPointsContractConfig(SetPointsContractConfigInput input)
+    {
+        CheckAdminPermission();
+        
+        Assert(input != null, "Invalid input.");
+        Assert(IsAddressValid(input!.PointsContract), "Invalid points contract.");
+        Assert(IsHashValid(input.DappId), "Invalid dapp id.");
+        Assert(IsAddressValid(input.Admin), "Invalid admin.");
+
+        var config = new PointsContractConfig
+        {
+            DappId = input.DappId,
+            Admin = input.Admin
+        };
+
+        if (State.PointsContractConfig.Value != null && State.PointsContractConfig.Value.Equals(config) &&
+            State.PointsContract.Value == input.PointsContract)
+            return new Empty();
+
+        State.PointsContract.Value = input.PointsContract;
+        State.PointsContractConfig.Value = config;
+
+        Context.Fire(new PointsContractConfigSet
+        {
+            Config = config,
+            PointsContract = input.PointsContract
+        });
+
+        return new Empty();
+    }
+
+    public override Empty Join(Empty input)
+    {
+        Assert(!State.JoinRecord[Context.Sender], "Already joined.");
+
+        Join(Context.Sender);
+
+        return new Empty();
+    }
+
+    public override Empty JoinFor(Address input)
+    {
+        Assert(
+            Context.Sender == State.EcoEarnTokensContract.Value || Context.Sender == State.EcoEarnPointsContract.Value,
+            "No permission.");
+        
+        Assert(IsAddressValid(input), "Invalid input.");
+
+        Join(input);
+
+        return new Empty();
+    }
+
+    public override Empty AcceptReferral(AcceptReferralInput input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsAddressValid(input!.Referrer) && State.JoinRecord[input.Referrer], "Invalid referrer.");
+        Assert(!State.JoinRecord[Context.Sender], "Already joined.");
+
+        State.JoinRecord[Context.Sender] = true;
+
+        var config = GetPointsContractConfig();
+
+        State.PointsContract.AcceptReferral.Send(new global::Points.Contracts.Point.AcceptReferralInput
+        {
+            DappId = config!.DappId,
+            Referrer = input.Referrer,
+            Invitee = Context.Sender
+        });
+
+        Context.Fire(new ReferralAccepted
+        {
+            Invitee = Context.Sender,
+            Referrer = input.Referrer
+        });
+
+        return new Empty();
+    }
+
+    public override Empty BatchSettle(BatchSettleInput input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsStringValid(input!.ActionName), "Invalid action name.");
+        Assert(input.UserPointsList != null && input.UserPointsList.Count > 0, "Invalid user points list.");
+
+        var config = GetPointsContractConfig();
+        Assert(Context.Sender == config.Admin, "No permission.");
+
+        var userPointsList = new List<global::Points.Contracts.Point.UserPoints>();
+        foreach (var userPoints in input.UserPointsList!)
+        {
+            Join(userPoints.UserAddress);
+            userPointsList.Add(new global::Points.Contracts.Point.UserPoints
+            {
+                UserAddress = userPoints.UserAddress,
+                UserPointsValue = userPoints.UserPointsValue
+            });
+        }
+
+        State.PointsContract.BatchSettle.Send(new global::Points.Contracts.Point.BatchSettleInput
+        {
+            ActionName = input.ActionName,
+            DappId = config.DappId,
+            UserPointsList = { userPointsList }
+        });
+
+        return new Empty();
+    }
+
+    #endregion
+
+    #region private
+
+    private string GetOfficialDomain(PointsContractConfig config)
+    {
+        var getDappInformationOutput = State.PointsContract.GetDappInformation.Call(new GetDappInformationInput
+        {
+            DappId = config.DappId
+        });
+        return getDappInformationOutput?.DappInfo.OfficialDomain;
+    }
+
+    private void Join(Address registrant, string domain = null)
+    {
+        if (State.JoinRecord[registrant]) return;
+
+        var config = GetPointsContractConfig();
+
+        domain ??= GetOfficialDomain(config);
+
+        State.JoinRecord[registrant] = true;
+
+        State.PointsContract.Join.Send(new JoinInput
+        {
+            Registrant = registrant,
+            DappId = config.DappId,
+            Domain = domain
+        });
+
+        Context.Fire(new Joined
+        {
+            Domain = domain,
+            Registrant = registrant
+        });
+    }
+
+    private PointsContractConfig GetPointsContractConfig()
+    {
+        var config = State.PointsContractConfig.Value;
+        Assert(config != null, "Points contract config not set.");
+
+        return config;
+    }
+
+    #endregion
+}

--- a/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_View.cs
+++ b/contract/EcoEarn.Contracts.Rewards/EcoEarnRewardsContract_View.cs
@@ -34,4 +34,21 @@ public partial class EcoEarnRewardsContract
     {
         return IsHashValid(input) ? State.LiquidityInfoMap[input] : new LiquidityInfo();
     }
+    
+    // PixiePoints
+    public override GetPointsContractConfigOutput GetPointsContractConfig(Empty input)
+    {
+        return new GetPointsContractConfigOutput
+        {
+            PointsContract = State.PointsContract.Value,
+            Config = State.PointsContractConfig.Value
+        };
+    }
+
+    public override BoolValue GetJoinRecord(Address input)
+    {
+        return IsAddressValid(input)
+            ? new BoolValue { Value = State.JoinRecord[input] }
+            : new BoolValue { Value = false };
+    }
 }

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContractState.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContractState.cs
@@ -37,4 +37,7 @@ public partial class EcoEarnTokensContractState : ContractState
 
     // <StakeId, LastOperationTime, UnlockWindowCount, IsClaimed>
     public MappedState<Hash, Timestamp, long, bool> WindowTermMap { get; set; }
+    
+    // dappId
+    public MappedState<Hash, bool> StakeOnBehalfPermissionMap { get; set; }
 }

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Pool.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Pool.cs
@@ -41,6 +41,8 @@ public partial class EcoEarnTokensContract
         };
 
         State.DappInfoMap[input.DappId] = info;
+        
+        Join(Context.Sender);
 
         Context.Fire(new Registered
         {
@@ -359,6 +361,25 @@ public partial class EcoEarnTokensContract
         return new Empty();
     }
 
+    public override Empty SetStakeOnBehalfPermission(StakeOnBehalfPermission input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsHashValid(input!.DappId), "Invalid dapp id.");
+        
+        CheckAdminPermission();
+
+        if (State.StakeOnBehalfPermissionMap[input.DappId] == input.Status) return new Empty();
+        State.StakeOnBehalfPermissionMap[input.DappId] = input.Status;
+        
+        Context.Fire(new StakeOnBehalfPermissionSet
+        {
+            DappId = input.DappId,
+            Status = input.Status
+        });
+        
+        return new Empty();
+    }
+
     #endregion
 
     #region private
@@ -442,6 +463,11 @@ public partial class EcoEarnTokensContract
     {
         return new BigIntValue(EcoEarnTokensContractConstants.Ten).Pow(
             EcoEarnTokensContractConstants.MaxDecimals.Sub(decimals));
+    }
+    
+    private void Join(Address registrant)
+    {
+        State.EcoEarnRewardsContract.JoinFor.Send(registrant);
     }
 
     #endregion

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Stake.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_Stake.cs
@@ -51,6 +51,8 @@ public partial class EcoEarnTokensContract
                 });
         }
         
+        Join(Context.Sender);
+        
         Context.Fire(new Staked
         {
             StakeInfo = stakeInfo,
@@ -215,6 +217,7 @@ public partial class EcoEarnTokensContract
         Assert(input != null, "Invalid input.");
 
         var poolInfo = GetPool(input!.PoolId);
+        Assert(State.StakeOnBehalfPermissionMap[poolInfo.DappId], "Permission not granted.");
 
         Assert(input!.Amount >= 0, "Invalid amount.");
         Assert(input.Period >= 0, "Invalid period.");
@@ -251,6 +254,8 @@ public partial class EcoEarnTokensContract
                     Symbol = poolInfo.Config.StakingToken
                 });
         }
+        
+        Join(input.Account);
         
         Context.Fire(new StakedOnBehalf
         {

--- a/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_View.cs
+++ b/contract/EcoEarn.Contracts.Tokens/EcoEarnTokensContract_View.cs
@@ -110,12 +110,12 @@ public partial class EcoEarnTokensContract
     {
         var poolInfo = State.PoolInfoMap[input.PoolId];
         if (poolInfo?.PoolId == null) return new BoolValue();
-        
+
         var stakeId = State.UserStakeIdMap[input.PoolId][input.Account];
         if (stakeId == null) return new BoolValue();
 
         var stakeInfo = State.StakeInfoMap[stakeId];
-        
+
         var remainTime = CalculateRemainTime(stakeInfo, poolInfo.Config.UnlockWindowDuration);
         if (stakeInfo != null && stakeInfo.UnlockTime == null && IsInUnlockWindow(stakeInfo, remainTime))
             return new BoolValue
@@ -124,6 +124,11 @@ public partial class EcoEarnTokensContract
             };
 
         return new BoolValue();
+    }
+
+    public override BoolValue GetStakeOnBehalfPermission(Hash input)
+    {
+        return IsHashValid(input) ? new BoolValue { Value = State.StakeOnBehalfPermissionMap[input] } : new BoolValue();
     }
 
     #endregion

--- a/protobuf/ecoearn_rewards.proto
+++ b/protobuf/ecoearn_rewards.proto
@@ -38,12 +38,23 @@ service EcoEarnRewardsContract {
   rpc RemoveLiquidity (RemoveLiquidityInput) returns (google.protobuf.Empty) {}
   rpc StakeLiquidity (StakeLiquidityInput) returns (google.protobuf.Empty) {}
   rpc GetLiquidityInfo (aelf.Hash) returns (LiquidityInfo) {option (aelf.is_view) = true;}
+
+  // points
+  rpc Join(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  rpc AcceptReferral (AcceptReferralInput) returns (google.protobuf.Empty) {}
+  rpc BatchSettle (BatchSettleInput) returns (google.protobuf.Empty) {}
+  rpc JoinFor(aelf.Address) returns (google.protobuf.Empty) {}
+  rpc SetPointsContractConfig(SetPointsContractConfigInput) returns (google.protobuf.Empty) {}
+  rpc GetPointsContractConfig(google.protobuf.Empty) returns (GetPointsContractConfigOutput) {option (aelf.is_view) = true;}
+  rpc GetJoinRecord(aelf.Address) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
 }
+
 message InitializeInput {
   aelf.Address admin = 1;
   aelf.Address ecoearn_points_contract = 2;
   aelf.Address ecoearn_tokens_contract = 3;
-  aelf.Address update_address = 4;
+  aelf.Address points_contract = 4;
+  aelf.Address update_address = 5;
 }
 
 message Config {
@@ -191,6 +202,36 @@ message LiquidityInfos {
   repeated LiquidityInfo data = 1;
 }
 
+message AcceptReferralInput {
+  aelf.Address referrer = 1;
+}
+
+message BatchSettleInput {
+  string action_name = 1;
+  repeated UserPoints user_points_list = 2;
+}
+
+message UserPoints {
+  aelf.Address user_address = 1;
+  aelf.BigIntValue user_points_value = 2;
+}
+
+message SetPointsContractConfigInput {
+  aelf.Address points_contract = 1;
+  aelf.Hash dapp_id = 2;
+  aelf.Address admin = 3;
+}
+
+message GetPointsContractConfigOutput {
+  aelf.Address points_contract = 1;
+  PointsContractConfig config = 2;
+}
+
+message PointsContractConfig {
+  aelf.Hash dapp_id = 1;
+  aelf.Address admin = 2;
+}
+
 // log event
 message ConfigSet {
   option (aelf.is_event) = true;
@@ -276,4 +317,22 @@ message LiquidityStaked {
   int64 period = 4;
   aelf.Hash stake_id = 5;
   aelf.Hash seed = 6;
+}
+
+message Joined {
+  option (aelf.is_event) = true;
+  string domain = 1;
+  aelf.Address registrant = 2;
+}
+
+message ReferralAccepted {
+  option (aelf.is_event) = true;
+  aelf.Address referrer = 1;
+  aelf.Address invitee = 2;
+}
+
+message PointsContractConfigSet {
+  option (aelf.is_event) = true;
+  aelf.Address points_contract = 1;
+  PointsContractConfig config = 2;
 }

--- a/protobuf/ecoearn_tokens.proto
+++ b/protobuf/ecoearn_tokens.proto
@@ -50,6 +50,8 @@ service EcoEarnTokensContract {
   rpc StakeOnBehalf (StakeOnBehalfInput) returns (google.protobuf.Empty) {}
   rpc IsInUnlockWindow (IsInUnlockWindowInput) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
   rpc SetDappConfig (SetDappConfigInput) returns (google.protobuf.Empty) {}
+  rpc SetStakeOnBehalfPermission(StakeOnBehalfPermission) returns (google.protobuf.Empty) {}
+  rpc GetStakeOnBehalfPermission(aelf.Hash) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
 }
 
 message RegisterInput {
@@ -295,6 +297,11 @@ message SetDappConfigInput {
   DappConfig config = 2;
 }
 
+message StakeOnBehalfPermission {
+  aelf.Hash dapp_id = 1;
+  bool status = 2;
+}
+
 // log event
 message Registered {
   option (aelf.is_event) = true;
@@ -422,4 +429,10 @@ message DappConfigSet {
   option (aelf.is_event) = true;
   aelf.Hash dapp_id = 1;
   DappConfig config = 2;
+}
+
+message StakeOnBehalfPermissionSet {
+  option (aelf.is_event) = true;
+  aelf.Hash dapp_id = 1;
+  bool status = 2;
 }

--- a/protobuf/points_contract.proto
+++ b/protobuf/points_contract.proto
@@ -7,11 +7,11 @@ import "acs12.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
-option csharp_namespace = "Points.Contracts.PointsContract";
+option csharp_namespace = "Points.Contracts.Point";
 
 service PointsContract {
     option (aelf.base) = "acs12.proto";
-    option (aelf.csharp_state) = "Points.Contracts.PointsContract.PointsContractState";
+    option (aelf.csharp_state) = "Points.Contracts.Point.PointsContractState";
 
     // Initialize.
     rpc Initialize(InitializeInput) returns (google.protobuf.Empty) {}
@@ -22,7 +22,7 @@ service PointsContract {
     rpc CreatePoint(CreatePointInput) returns (google.protobuf.Empty) {}
     rpc CreatePointList(CreatePointListInput) returns (google.protobuf.Empty) {}
     rpc GetPoint(GetPointInput) returns (PointInfo){ option (aelf.is_view) = true; }
-    
+
     rpc SetMaxApplyDomainCount(google.protobuf.Int32Value) returns (google.protobuf.Empty){}
 
     rpc Join(JoinInput) returns (google.protobuf.Empty) {}
@@ -50,7 +50,7 @@ message InitializeInput {
 }
 
 message JoinInput {
-    aelf.Hash dapp_id = 1; 
+    aelf.Hash dapp_id = 1;
     string domain = 2; // 
     aelf.Address registrant = 3;
 }
@@ -103,7 +103,7 @@ message PointsChangedDetail {
     IncomeSourceType income_source_type = 3;
     string domain = 4;
     string action_name = 5;
-    string points_name = 6;  
+    string points_name = 6;
     int64 increase_amount = 7;
     int64 balance = 8;
     aelf.BigIntValue balance_value = 9;
@@ -162,14 +162,20 @@ message SetDappPointsRulesInput {
     PointsRuleList dapp_points_rules = 2;
 }
 
+message DappPointsRulesSet {
+    option (aelf.is_event) = true;
+    aelf.Hash dapp_id = 1;
+    PointsRuleList dapp_points_rules = 2;
+}
+
 message DappAdded {
     option (aelf.is_event) = true;
-    aelf.Hash dapp_id = 1; 
+    aelf.Hash dapp_id = 1;
     DappInfo dapp_info = 2;
 }
 
 message GetDappInformationInput {
-    aelf.Hash dapp_id = 1; 
+    aelf.Hash dapp_id = 1;
 }
 
 message GetDappInformationOutput {
@@ -186,9 +192,9 @@ message SelfIncreasingPointsRulesChanged {
     option (aelf.is_event) = true;
     aelf.Hash dapp_id = 1;
     string point_name = 2;
-    int64 user_points = 3; 
-    int64 kol_points_percent = 4; 
-    int64 inviter_points_percent = 5; 
+    int64 user_points = 3;
+    int64 kol_points_percent = 4;
+    int64 inviter_points_percent = 5;
     int32 frequency = 6;
     bool enable_proportional_calculation = 7;
 }
@@ -215,12 +221,6 @@ message InviterApplied {
     aelf.Address inviter = 4;
 }
 
-message DappPointsRuleChanged {
-    option (aelf.is_event) = true;
-    string service = 1;
-    PointsRuleList dapp_earning_rules = 2;
-}
-
 message PointInfo {
     string token_name = 1;
     int32 decimals = 2;
@@ -240,8 +240,8 @@ message ReservedDomainList {
 
 message DomainRelationshipInfo {
     string domain = 1;
-    aelf.Address invitee = 2; 
-    aelf.Address inviter = 3; 
+    aelf.Address invitee = 2;
+    aelf.Address inviter = 3;
 }
 
 message CreatePointInput {

--- a/protobuf/test_points_contract.proto
+++ b/protobuf/test_points_contract.proto
@@ -14,6 +14,9 @@ service TestPointsContract {
   rpc Initialize(InitializeInput) returns (google.protobuf.Empty) {}
   rpc GetPoint(GetPointInput) returns (PointInfo){ option (aelf.is_view) = true; }
   rpc GetDappInformation(GetDappInformationInput) returns (GetDappInformationOutput) { option (aelf.is_view) = true; }
+  rpc Join(JoinInput) returns (google.protobuf.Empty) {}
+  rpc AcceptReferral(AcceptReferralInput) returns (google.protobuf.Empty) {}
+  rpc BatchSettle(BatchSettleInput) returns (google.protobuf.Empty) {}
 }
 
 message InitializeInput {
@@ -56,4 +59,28 @@ message PointsRule {
   int64 kol_points_percent = 4;
   int64 inviter_points_percent = 5;
   bool enable_proportional_calculation = 6;
+}
+
+message JoinInput {
+  aelf.Hash dapp_id = 1;
+  string domain = 2;
+  aelf.Address registrant = 3;
+}
+
+message AcceptReferralInput {
+  aelf.Hash dapp_id = 1;
+  aelf.Address referrer = 2;
+  aelf.Address invitee = 3;
+}
+
+message BatchSettleInput {
+  string action_name = 1;
+  aelf.Hash dapp_id = 2;
+  repeated UserPoints user_points_list = 3;
+}
+
+message UserPoints {
+  aelf.Address user_address = 1;
+  int64 user_points = 2;
+  aelf.BigIntValue user_points_value = 3;
 }

--- a/test/EcoEarn.Contracts.Points.Tests/EcoEarnPointsContractTests_Admin.cs
+++ b/test/EcoEarn.Contracts.Points.Tests/EcoEarnPointsContractTests_Admin.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using AElf.Types;
+using EcoEarn.Contracts.Rewards;
 using Google.Protobuf.WellKnownTypes;
 using Shouldly;
 using Xunit;
@@ -286,11 +287,18 @@ public partial class EcoEarnPointsContractTests : EcoEarnPointsContractTestBase
         {
             EcoearnTokensContract = EcoEarnTokensContractAddress,
             EcoearnPointsContract = EcoEarnPointsContractAddress,
+            PointsContract = PointsContractAddress,
             UpdateAddress = DefaultAddress
         });
         await PointsContractStub.Initialize.SendAsync(new TestPointsContract.InitializeInput
         {
             PointsName = PointsName
+        });
+        await EcoEarnRewardsContractStub.SetPointsContractConfig.SendAsync(new SetPointsContractConfigInput
+        {
+            Admin = DefaultAddress,
+            DappId = _appId,
+            PointsContract = PointsContractAddress
         });
     }
 }

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Admin.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Admin.cs
@@ -17,6 +17,7 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
             Admin = UserAddress,
             EcoearnPointsContract = EcoEarnPointsContractAddress,
             EcoearnTokensContract = EcoEarnTokensContractAddress,
+            PointsContract = PointsContractAddress,
             UpdateAddress = DefaultAddress
         };
 
@@ -69,12 +70,29 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
             EcoearnPointsContract = DefaultAddress,
             EcoearnTokensContract = DefaultAddress
         });
+        result.TransactionResult.Error.ShouldContain("Invalid points contract.");
+        
+        result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            EcoearnPointsContract = DefaultAddress,
+            EcoearnTokensContract = DefaultAddress,
+            PointsContract = new Address()
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid points contract.");
+        
+        result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
+        {
+            EcoearnPointsContract = DefaultAddress,
+            EcoearnTokensContract = DefaultAddress,
+            PointsContract = DefaultAddress
+        });
         result.TransactionResult.Error.ShouldContain("Invalid update address.");
         
         result = await EcoEarnRewardsContractStub.Initialize.SendWithExceptionAsync(new InitializeInput
         {
             EcoearnPointsContract = DefaultAddress,
             EcoearnTokensContract = DefaultAddress,
+            PointsContract = DefaultAddress,
             UpdateAddress = new Address()
         });
         result.TransactionResult.Error.ShouldContain("Invalid update address.");
@@ -126,6 +144,7 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
         {
             EcoearnPointsContract = EcoEarnPointsContractAddress,
             EcoearnTokensContract = EcoEarnTokensContractAddress,
+            PointsContract = PointsContractAddress,
             UpdateAddress = DefaultAddress
         });
         await EcoEarnPointsContractStub.Initialize.SendAsync(new Points.InitializeInput
@@ -150,6 +169,14 @@ public partial class EcoEarnRewardsContractTests : EcoEarnRewardsContractTestBas
         {
             PointsName = PointsName
         });
+        
+        await EcoEarnRewardsContractStub.SetPointsContractConfig.SendAsync(new SetPointsContractConfigInput
+        {
+            Admin = DefaultAddress,
+            DappId = _appIdEcoEarn,
+            PointsContract = PointsContractAddress
+        });
+        
         await EcoEarnPointsContractStub.Register.SendAsync(new Points.RegisterInput
         {
             DappId = _appId

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_DApp.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_DApp.cs
@@ -15,6 +15,7 @@ public partial class EcoEarnRewardsContractTests
     private const string Symbol = "SGR-1";
     private const string DefaultSymbol = "ELF";
     private readonly Hash _appId = HashHelper.ComputeFrom("dapp");
+    private readonly Hash _appIdEcoEarn = HashHelper.ComputeFrom("ecoearn");
 
     [Fact]
     public async Task RegisterTests()

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Points.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Points.cs
@@ -1,0 +1,271 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AElf.Types;
+using Google.Protobuf.WellKnownTypes;
+using Shouldly;
+using Xunit;
+
+namespace EcoEarn.Contracts.Rewards;
+
+public partial class EcoEarnRewardsContractTests
+{
+    [Fact]
+    public async Task SetPointsContractConfigTests()
+    {
+        await InitializeWithoutRegister();
+        
+        var result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendAsync(new SetPointsContractConfigInput
+        {
+            Admin = DefaultAddress,
+            DappId = _appIdEcoEarn,
+            PointsContract = PointsContractAddress
+        });
+        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+
+        var log = GetLogEvent<PointsContractConfigSet>(result.TransactionResult);
+        log.PointsContract.ShouldBe(PointsContractAddress);
+        log.Config.Admin.ShouldBe(DefaultAddress);
+        log.Config.DappId.ShouldBe(_appIdEcoEarn);
+        
+        var output = await EcoEarnRewardsContractStub.GetPointsContractConfig.CallAsync(new Empty());
+        output.PointsContract.ShouldBe(PointsContractAddress);
+        output.Config.ShouldBe(log.Config);
+        
+        result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendAsync(new SetPointsContractConfigInput
+        {
+            Admin = DefaultAddress,
+            DappId = _appIdEcoEarn,
+            PointsContract = PointsContractAddress
+        });
+        result.TransactionResult.Logs.FirstOrDefault(l => l.Name == nameof(PointsContractConfigSet)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetRewardsContractConfigTests_Fail()
+    {
+        await Initialize();
+
+        var result =
+            await UserEcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+                new SetPointsContractConfigInput());
+        result.TransactionResult.Error.ShouldContain("No permission.");
+
+        result =
+            await EcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+                new SetPointsContractConfigInput());
+        result.TransactionResult.Error.ShouldContain("Invalid points contract.");
+
+        result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+            new SetPointsContractConfigInput
+            {
+                PointsContract = new Address()
+            });
+        result.TransactionResult.Error.ShouldContain("Invalid points contract.");
+        
+        result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+            new SetPointsContractConfigInput
+            {
+                PointsContract = DefaultAddress
+            });
+        result.TransactionResult.Error.ShouldContain("Invalid dapp id.");
+        
+        result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+            new SetPointsContractConfigInput
+            {
+                PointsContract = DefaultAddress,
+                DappId = new Hash()
+            });
+        result.TransactionResult.Error.ShouldContain("Invalid dapp id.");
+        
+        result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+            new SetPointsContractConfigInput
+            {
+                PointsContract = DefaultAddress,
+                DappId = _appIdEcoEarn
+            });
+        result.TransactionResult.Error.ShouldContain("Invalid admin.");
+        
+        result = await EcoEarnRewardsContractStub.SetPointsContractConfig.SendWithExceptionAsync(
+            new SetPointsContractConfigInput
+            {
+                PointsContract = DefaultAddress,
+                DappId = _appIdEcoEarn,
+                Admin = new Address()
+            });
+        result.TransactionResult.Error.ShouldContain("Invalid admin.");
+    }
+    
+    [Fact]
+    public async Task JoinTests()
+    {
+        await Initialize();
+        
+        var output = await EcoEarnRewardsContractStub.GetJoinRecord.CallAsync(UserAddress);
+        output.Value.ShouldBe(false);
+
+        var result = await UserEcoEarnRewardsContractStub.Join.SendAsync(new Empty());
+        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+
+        var log = GetLogEvent<Joined>(result.TransactionResult);
+        log.Domain.ShouldBe("domain");
+        log.Registrant.ShouldBe(UserAddress);
+
+        output = await EcoEarnRewardsContractStub.GetJoinRecord.CallAsync(UserAddress);
+        output.Value.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task JoinTests_Fail()
+    {
+        await InitializeWithoutRegister();
+        
+        var result = await EcoEarnRewardsContractStub.Join.SendWithExceptionAsync(new Empty());
+        result.TransactionResult.Error.ShouldContain("Points contract config not set.");
+        
+        await EcoEarnRewardsContractStub.SetPointsContractConfig.SendAsync(new SetPointsContractConfigInput
+        {
+            Admin = DefaultAddress,
+            DappId = _appIdEcoEarn,
+            PointsContract = PointsContractAddress
+        });
+        
+        await EcoEarnRewardsContractStub.Join.SendAsync(new Empty());
+        
+        result = await EcoEarnRewardsContractStub.Join.SendWithExceptionAsync(new Empty());
+        result.TransactionResult.Error.ShouldContain("Already joined.");
+    }
+
+    [Fact]
+    public async Task JoinForTests_Fail()
+    {
+        var result = await EcoEarnRewardsContractStub.JoinFor.SendWithExceptionAsync(DefaultAddress);
+        result.TransactionResult.Error.ShouldContain("No permission.");
+    }
+
+    [Fact]
+    public async Task AcceptReferralTests()
+    {
+        await Initialize();
+
+        var result = await UserEcoEarnRewardsContractStub.AcceptReferral.SendAsync(new AcceptReferralInput
+        {
+            Referrer = DefaultAddress
+        });
+        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+
+        var log = GetLogEvent<ReferralAccepted>(result.TransactionResult);
+        log.Referrer.ShouldBe(DefaultAddress);
+        log.Invitee.ShouldBe(UserAddress);
+
+        var output = await EcoEarnRewardsContractStub.GetJoinRecord.CallAsync(UserAddress);
+        output.Value.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AcceptReferralTests_Fail()
+    {
+        var result = await UserEcoEarnRewardsContractStub.AcceptReferral.SendWithExceptionAsync(new AcceptReferralInput());
+        result.TransactionResult.Error.ShouldContain("Invalid referrer.");
+        
+        result = await UserEcoEarnRewardsContractStub.AcceptReferral.SendWithExceptionAsync(new AcceptReferralInput
+        {
+            Referrer = new Address()
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid referrer.");
+        
+        result = await UserEcoEarnRewardsContractStub.AcceptReferral.SendWithExceptionAsync(new AcceptReferralInput
+        {
+            Referrer = DefaultAddress
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid referrer.");
+    }
+
+    [Fact]
+    public async Task BatchSettleTests()
+    {
+        await Initialize();
+        
+        var result = await EcoEarnRewardsContractStub.BatchSettle.SendAsync(new BatchSettleInput
+        {
+            ActionName = "action",
+            UserPointsList = { new UserPoints
+            {
+                UserAddress = DefaultAddress,
+                UserPointsValue = new BigIntValue
+                {
+                    Value = "100000000"
+                }
+            } }
+        });
+        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+    }
+
+    [Fact]
+    public async Task BatchSettleTests_Fail()
+    {
+        var result = await EcoEarnRewardsContractStub.BatchSettle.SendWithExceptionAsync(new BatchSettleInput());
+        result.TransactionResult.Error.ShouldContain("Invalid action name.");
+        
+        result = await EcoEarnRewardsContractStub.BatchSettle.SendWithExceptionAsync(new BatchSettleInput
+        {
+            ActionName = "action"
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid user points list.");
+        
+        result = await EcoEarnRewardsContractStub.BatchSettle.SendWithExceptionAsync(new BatchSettleInput
+        {
+            ActionName = "action",
+            UserPointsList = {  }
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid user points list.");
+        
+        result = await EcoEarnRewardsContractStub.BatchSettle.SendWithExceptionAsync(new BatchSettleInput
+        {
+            ActionName = "action",
+            UserPointsList = { new UserPoints() }
+        });
+        result.TransactionResult.Error.ShouldContain("Points contract config not set.");
+
+        await Initialize();
+        
+        result = await UserEcoEarnRewardsContractStub.BatchSettle.SendWithExceptionAsync(new BatchSettleInput
+        {
+            ActionName = "action",
+            UserPointsList = { new UserPoints() }
+        });
+        result.TransactionResult.Error.ShouldContain("No permission.");
+    }
+
+    private async Task InitializeWithoutRegister()
+    {
+        await EcoEarnRewardsContractStub.Initialize.SendAsync(new InitializeInput
+        {
+            EcoearnPointsContract = EcoEarnPointsContractAddress,
+            EcoearnTokensContract = EcoEarnTokensContractAddress,
+            PointsContract = PointsContractAddress,
+            UpdateAddress = DefaultAddress
+        });
+        await EcoEarnPointsContractStub.Initialize.SendAsync(new Points.InitializeInput
+        {
+            PointsContract = PointsContractAddress,
+            CommissionRate = 1000,
+            Recipient = User2Address,
+            EcoearnTokensContract = EcoEarnTokensContractAddress,
+            EcoearnRewardsContract = EcoEarnRewardsContractAddress,
+            UpdateAddress = DefaultAddress
+        });
+        await EcoEarnTokensContractStub.Initialize.SendAsync(new Tokens.InitializeInput
+        {
+            CommissionRate = 100,
+            Recipient = User2Address,
+            EcoearnPointsContract = EcoEarnPointsContractAddress,
+            EcoearnRewardsContract = EcoEarnRewardsContractAddress,
+            IsRegisterRestricted = true,
+            MaximumPositionCount = 100
+        });
+        await PointsContractStub.Initialize.SendAsync(new TestPointsContract.InitializeInput
+        {
+            PointsName = PointsName
+        });
+    }
+}

--- a/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Reward.cs
+++ b/test/EcoEarn.Contracts.Rewards.Tests/EcoEarnRewardsContractTests_Reward.cs
@@ -71,6 +71,7 @@ public partial class EcoEarnRewardsContractTests
         {
             EcoearnPointsContract = DefaultAddress,
             EcoearnTokensContract = DefaultAddress,
+            PointsContract = PointsContractAddress,
             UpdateAddress = DefaultAddress
         });
 

--- a/test/EcoEarn.Contracts.TestPointsContract/Action.cs
+++ b/test/EcoEarn.Contracts.TestPointsContract/Action.cs
@@ -15,6 +15,24 @@ public class TestPointsContract : TestPointsContractContainer.TestPointsContract
     public override GetDappInformationOutput GetDappInformation(GetDappInformationInput input)
     {
         if (input.DappId == HashHelper.ComputeFrom("test")) return new GetDappInformationOutput();
+        if (input.DappId == HashHelper.ComputeFrom("ecoearn")) return new GetDappInformationOutput
+        {
+            DappInfo = new DappInfo
+            {
+                DappAdmin = State.Admin.Value,
+                DappsPointRules = new PointsRuleList
+                {
+                    PointsRules =
+                    {
+                        new PointsRule
+                        {
+                            PointName = State.PointsName.Value
+                        }
+                    }
+                },
+                OfficialDomain = "domain"
+            }
+        };
         return new GetDappInformationOutput
         {
             DappInfo = new DappInfo
@@ -37,11 +55,33 @@ public class TestPointsContract : TestPointsContractContainer.TestPointsContract
     public override PointInfo GetPoint(GetPointInput input)
     {
         if (input.PointsName == "Test") return new PointInfo();
-
+        if (input.PointsName == "EcoEarn")
+        {
+            return new PointInfo
+            {
+                TokenName = "EcoEarn",
+                Decimals = 0
+            };
+        }
         return new PointInfo
         {
             TokenName = "test",
             Decimals = 0
         };
+    }
+
+    public override Empty Join(JoinInput input)
+    {
+        return new Empty();
+    }
+
+    public override Empty AcceptReferral(AcceptReferralInput input)
+    {
+        return new Empty();
+    }
+
+    public override Empty BatchSettle(BatchSettleInput input)
+    {
+        return new Empty();
     }
 }

--- a/test/EcoEarn.Contracts.Tokens.Tests/EcoEarnTokensContractTests_Stake.cs
+++ b/test/EcoEarn.Contracts.Tokens.Tests/EcoEarnTokensContractTests_Stake.cs
@@ -779,6 +779,12 @@ public partial class EcoEarnTokensContractTests
             PoolId = poolId
         });
         userStakeId.ShouldBe(new Hash());
+
+        await EcoEarnTokensContractStub.SetStakeOnBehalfPermission.SendAsync(new StakeOnBehalfPermission
+        {
+            DappId = _appId,
+            Status = true
+        });
         
         // create position
         {
@@ -925,6 +931,18 @@ public partial class EcoEarnTokensContractTests
             PoolId = HashHelper.ComputeFrom("test")
         });
         result.TransactionResult.Error.ShouldContain("Pool not exists.");
+        
+        result = await EcoEarnTokensContractStub.StakeOnBehalf.SendWithExceptionAsync(new StakeOnBehalfInput
+        {
+            PoolId = poolId
+        });
+        result.TransactionResult.Error.ShouldContain("Permission not granted.");
+
+        await EcoEarnTokensContractStub.SetStakeOnBehalfPermission.SendAsync(new StakeOnBehalfPermission
+        {
+            DappId = _appId,
+            Status = true
+        });
         
         result = await EcoEarnTokensContractStub.StakeOnBehalf.SendWithExceptionAsync(new StakeOnBehalfInput
         {


### PR DESCRIPTION
- Develop `Join`, `AcceptReferral`, and `BatchSettle` in Rewards Contract.
- Integrate the Join logic into `Register` in Rewards contract.
- Integrate the Join logic into `Register`, `Stake` and `StakeOnBehalf` in Tokens contract.
- Integrate the Join logic into `Register` and `Claim` in Points contract.
- Develop data structure in Rewards contract to store Join records, address for BatchSettle, and dapp id.
- Develop `JoinFor` as internal interface in Rewards contract for Points and Tokens contract to call since only one contract address can be registered in PixiePoints contract.
close #13 